### PR TITLE
Requests merging intrerface implementation

### DIFF
--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -3419,7 +3419,7 @@ bdev_io_submit(struct spdk_bdev_io *bdev_io)
 
 	if (!TAILQ_EMPTY(&ch->locked_ranges)) {
 		struct lba_range *range;
-
+		
 		TAILQ_FOREACH(range, &ch->locked_ranges, tailq) {
 			if (bdev_io_range_is_locked(bdev_io, range)) {
 				TAILQ_INSERT_TAIL(&ch->io_locked, bdev_io, internal.ch_link);

--- a/module/bdev/raid/Makefile
+++ b/module/bdev/raid/Makefile
@@ -10,7 +10,7 @@ SO_VER := 5
 SO_MINOR := 0
 
 CFLAGS += -I$(SPDK_ROOT_DIR)/lib/bdev/
-C_SRCS = bdev_raid.c bdev_raid_rpc.c raid0.c raid1.c concat.c raid_request_merge.c ht.c
+C_SRCS = ht.c raid_request_merge.c bdev_raid.c bdev_raid_rpc.c raid0.c raid1.c concat.c
 
 ifeq ($(CONFIG_RAID5F),y)
 C_SRCS += raid5f.c

--- a/module/bdev/raid/Makefile
+++ b/module/bdev/raid/Makefile
@@ -10,7 +10,7 @@ SO_VER := 5
 SO_MINOR := 0
 
 CFLAGS += -I$(SPDK_ROOT_DIR)/lib/bdev/
-C_SRCS = bdev_raid.c bdev_raid_rpc.c raid0.c raid1.c concat.c raid5.c
+C_SRCS = bdev_raid.c bdev_raid_rpc.c raid0.c raid1.c concat.c raid_request_merge.c ht.c
 
 ifeq ($(CONFIG_RAID5F),y)
 C_SRCS += raid5f.c

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1011,6 +1011,7 @@ raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 		return -ENOMEM;
 	}
 
+	raid_bdev->merge_request_poller = NULL;
 	raid_bdev->module = module;
 	raid_bdev->num_base_bdevs = num_base_bdevs;
 	raid_bdev->base_bdev_info = calloc(raid_bdev->num_base_bdevs,

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -144,6 +144,9 @@ struct raid_bdev {
 	/* Raid Level of this raid bdev */
 	enum raid_level			level;
 
+	/* Poller responsible for merging requests */
+	struct spdk_poller *merge_request_poller;
+
 	/* Set to true if destroy of this raid bdev is started. */
 	bool				destroy_started;
 

--- a/module/bdev/raid/ht.c
+++ b/module/bdev/raid/ht.c
@@ -1,0 +1,218 @@
+/*   SPDX-License-Identifier: BSD-3-Clause
+ *   All rights reserved.
+ */
+
+#include "ht.h"
+
+ht *
+ht_create(void)
+{
+    ht *table = (ht *)malloc(sizeof(ht));
+
+    if (table == NULL)
+    {
+        return NULL;
+    }
+
+    table->length = 0;
+    table->capacity = INITIAL_CAPACITY;
+    table->entries = (ht_entry *)calloc(table->capacity, sizeof(ht_entry));
+
+    if (table->entries == NULL)
+    {
+        free(table);
+        return NULL;
+    }
+
+    return table;
+}
+
+void
+ht_destroy(ht *table)
+{
+    for (size_t i = 0; i < table->capacity; i++)
+    {
+        free((void *)table->entries[i].key);
+    }
+
+    free(table->entries);
+    free(table);
+}
+
+static uint64_t
+hash_key(const char *key)
+{
+    uint64_t hash = FNV_OFFSET;
+
+    for (const char *p = key; *p; p++)
+    {
+        hash ^= (uint64_t)(unsigned char)(*p);
+        hash *= FNV_PRIME;
+    }
+
+    return hash;
+}
+
+void *
+ht_get(ht *table, const char *key)
+{
+    uint64_t hash = hash_key(key);
+    size_t index = (size_t)(hash & (uint64_t)(table->capacity - 1));
+
+    while (table->entries[index].key != NULL)
+    {
+
+        if (strcmp(key, table->entries[index].key) == 0)
+            return table->entries[index].value;
+
+        index++;
+        if (index >= table->capacity)
+        {
+            index = 0;
+        }
+    }
+
+    return NULL;
+}
+
+static const char *
+ht_set_entry(ht_entry *entries, size_t capacity, const char *key, void *value, size_t *plength)
+{
+    uint64_t hash = hash_key(key);
+    size_t index = (size_t)(hash & (uint64_t)(capacity - 1));
+
+    while (entries[index].key != NULL)
+    {
+
+        if (strcmp(key, entries[index].key) == 0)
+        {
+            entries[index].value = value;
+            return entries[index].key;
+        }
+
+        index++;
+        if (index >= capacity)
+        {
+            index = 0;
+        }
+    }
+
+    if (plength != NULL)
+    {
+        key = strdup(key);
+        if (key == NULL)
+            return NULL;
+        (*plength)++;
+    }
+
+    entries[index].key = (char *)key;
+    entries[index].value = value;
+    return key;
+}
+
+static bool
+ht_expand(ht *table)
+{
+    size_t new_capacity = table->capacity * 2;
+    if (new_capacity < table->capacity)
+    {
+        return false;
+    }
+
+    ht_entry *new_entries = (ht_entry *)calloc(new_capacity, sizeof(ht_entry));
+    if (new_entries == NULL)
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < table->capacity; i++)
+    {
+        ht_entry entry = table->entries[i];
+        if (entry.key != NULL)
+            ht_set_entry(new_entries, new_capacity, entry.key, entry.value, NULL);
+    }
+
+    free(table->entries);
+    table->entries = new_entries;
+    table->capacity = new_capacity;
+    return true;
+}
+
+const char *
+ht_set(ht *table, const char *key, void *value)
+{
+    assert(value != NULL);
+    if (value == NULL)
+    {
+        return NULL;
+    }
+
+    if (table->length >= table->capacity / 2)
+    {
+        if (!ht_expand(table))
+            return NULL;
+    }
+
+    return ht_set_entry(table->entries, table->capacity, key, value, &table->length);
+}
+
+void *
+ht_remove(ht *table, const char *key)
+{
+    uint64_t hash = hash_key(key);
+    size_t index = (size_t)(hash & (uint64_t)(table->capacity - 1));
+
+    while (table->entries[index].key != NULL)
+    {
+
+        if (strcmp(key, table->entries[index].key) == 0)
+        {
+            table->entries[index].value = NULL;
+            table->length--;
+            return table->entries[index].value;
+        }
+
+        index++;
+
+        if (index >= table->capacity)
+            index = 0;
+    }
+
+    return NULL;
+}
+
+size_t
+ht_length(ht *table)
+{
+    return table->length;
+}
+
+hti
+ht_iterator(ht *table)
+{
+    hti it;
+    it._table = table;
+    it._index = 0;
+    return it;
+}
+
+bool
+ht_next(hti *it)
+{
+    ht *table = it->_table;
+    while (it->_index < table->capacity)
+    {
+
+        size_t i = it->_index;
+        it->_index++;
+
+        if (table->entries[i].key != NULL)
+        {
+            ht_entry entry = table->entries[i];
+            it->key = entry.key;
+            it->value = entry.value;
+            return true;
+        }
+    }
+    return false;
+}

--- a/module/bdev/raid/ht.h
+++ b/module/bdev/raid/ht.h
@@ -1,0 +1,43 @@
+/*   SPDX-License-Identifier: BSD-3-Clause
+ *   All rights reserved.
+ */
+
+#ifndef SPDK_HT_H
+#define SPDK_HT_H
+
+#include "spdk/stdinc.h"
+#include "string.h"
+
+#define INITIAL_CAPACITY 16
+#define FNV_OFFSET 14695981039346656037UL
+#define FNV_PRIME 1099511628211UL
+
+typedef struct {
+    const char *key;
+    void *value;
+} ht_entry;
+
+typedef struct {
+    ht_entry *entries;
+    size_t capacity;
+    size_t length;
+} ht;
+
+typedef struct {
+    const char *key;
+    void *value;
+
+    ht *_table;
+    size_t _index;
+} hti;
+
+ht * ht_create(void);
+void ht_destroy(ht *table);
+void * ht_get(ht *table, const char *key);
+const char * ht_set(ht *table, const char *key, void *value);
+void * ht_remove(ht *table, const char *key);
+size_t ht_length(ht *table);
+hti ht_iterator(ht *table);
+bool ht_next(hti *it);
+
+#endif

--- a/module/bdev/raid/raid_request_merge.c
+++ b/module/bdev/raid/raid_request_merge.c
@@ -1,0 +1,218 @@
+/*   SPDX-License-Identifier: BSD-3-Clause
+ *   Copyright (C) 2019 Intel Corporation.
+ *   All rights reserved.
+ *   Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ */
+
+#include "bdev_raid.h"
+
+#include "spdk/tree.h"
+#include "spdk/log.h"
+#include "spdk/bdev.h"
+#include "spdk/bdev_module.h"
+#include "bdev_internal.h"
+
+#include "raid_request_merge.h"
+#include "ht.h"
+
+static int
+addr_cmp(struct raid_write_request *c1, struct raid_write_request *c2)
+{
+    return (c1->addr < c2->addr ? -1 : c1->addr > c2->addr);
+}
+
+RB_GENERATE_STATIC(raid_addr_tree, raid_write_request, link, addr_cmp);
+
+ht *raid_ht = NULL;
+
+static void
+clear_tree(struct raid_request_tree *tree)
+{
+    struct raid_write_request *current_request;
+
+    RB_FOREACH(current_request, raid_addr_tree, &tree->tree)
+    {
+        RB_REMOVE(raid_addr_tree, &tree->tree, current_request);
+    }
+    tree->size = 0;
+}
+
+static void
+tmp_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev, void *ctx)
+{
+    SPDK_NOTICELOG("Unexpected event type: %d\n", type);
+}
+
+static int
+raid_create_big_write_request(char *stripe_key, struct raid_bdev_io **big_raid_bdev_io)
+{
+    struct spdk_bdev_desc *desc;
+    struct spdk_bdev_io *bdev_io;
+    struct spdk_bdev_io *current_request_bdev_io;
+    struct raid_bdev_io *raid_io;
+    struct raid_request_tree *stripe_tree;
+    struct raid_write_request *current_request;
+    struct spdk_io_channel *ch;
+    struct spdk_bdev_channel *channel;
+    struct raid_bdev *raid_bdev = NULL;
+    struct spdk_bdev *bdev = NULL;
+    struct iovec *iovs = NULL;
+    size_t iovs_size = 0;
+    uint64_t num_blocks = 0;
+    uint64_t offset_blocks;
+    char *bdev_name;
+    int iovcnt = 0;
+    int rc;
+    
+    stripe_tree = ht_get(raid_ht, stripe_key);
+    current_request = RB_MIN(raid_addr_tree, &stripe_tree->tree);
+
+    current_request_bdev_io = spdk_bdev_io_from_ctx(current_request->bdev_io);
+    raid_bdev = current_request->bdev_io->raid_bdev;
+    bdev = &raid_bdev->bdev;
+    bdev_name = raid_bdev->bdev.name;
+
+    offset_blocks = current_request_bdev_io->u.bdev.offset_blocks;
+
+    rc = spdk_bdev_open_ext(bdev_name, false, tmp_bdev_event_cb, NULL, &desc);
+
+    if (rc != 0)
+    {
+        SPDK_ERRLOG("Failed to open bdev with name: %s\n", bdev_name);
+        return rc;
+    }
+
+    ch = spdk_bdev_get_io_channel(desc);
+    channel = (struct spdk_bdev_channel *)spdk_io_channel_get_ctx(ch);
+
+    bdev_io = (struct spdk_bdev_io *)bdev_channel_get_io(channel);
+    {
+        if (!bdev_io)
+            return -ENOMEM;
+    }
+
+    RB_FOREACH(current_request, raid_addr_tree, &stripe_tree->tree)
+    {
+        current_request_bdev_io = spdk_bdev_io_from_ctx(current_request->bdev_io);
+        iovs_size += sizeof(struct iovec) * current_request_bdev_io->u.bdev.iovcnt;
+        iovs = realloc(iovs, iovs_size);
+        for (int i = 0; i < current_request_bdev_io->u.bdev.iovcnt; i++)
+        {
+            num_blocks += bdev_io->u.bdev.iovs[i].iov_len / bdev->blocklen;
+        }
+        memcpy(iovs + iovcnt, current_request_bdev_io->u.bdev.iovs, sizeof(struct iovec) * current_request_bdev_io->u.bdev.iovcnt);
+        iovcnt += current_request_bdev_io->u.bdev.iovcnt;
+    }
+
+    bdev_io->internal.ch = channel;
+    bdev_io->internal.desc = desc;
+    bdev_io->type = SPDK_BDEV_IO_TYPE_WRITE;
+    bdev_io->u.bdev.iovs = iovs;
+    bdev_io->u.bdev.iovcnt = iovcnt;
+    bdev_io->u.bdev.md_buf = NULL;
+    bdev_io->u.bdev.num_blocks = num_blocks;
+    bdev_io->u.bdev.offset_blocks = offset_blocks;
+    bdev_io->u.bdev.memory_domain = NULL;
+    bdev_io->u.bdev.memory_domain_ctx = NULL;
+    bdev_io->u.bdev.accel_sequence = NULL;
+    bdev_io_init(bdev_io, bdev, spdk_bdev_io_complete, NULL);
+    bdev_io_submit(bdev_io);
+
+    raid_io = (struct raid_bdev_io *)bdev_io->driver_ctx;
+
+    raid_io->raid_bdev = bdev_io->bdev->ctxt;
+    raid_io->raid_ch = spdk_io_channel_get_ctx(ch);
+    raid_io->base_bdev_io_remaining = 0;
+    raid_io->base_bdev_io_submitted = 0;
+    raid_io->base_bdev_io_status = SPDK_BDEV_IO_STATUS_SUCCESS;
+
+    *big_raid_bdev_io = raid_io;
+
+    return 0;
+
+}
+
+int
+raid_request_catch(struct raid_bdev_io *raid_io)
+{
+    struct raid_write_request *write_request;
+    struct spdk_bdev_io *bdev_io;
+    struct raid_bdev *raid_bdev;
+    struct raid_request_tree *stripe_tree;
+    char stripe_key[MAX_HT_STRING_LEN];
+    uint64_t stripe_index;
+    uint64_t start_strip_idx;
+    uint8_t max_tree_size;
+    int rc;
+
+    write_request = malloc(sizeof(struct raid_write_request));
+    bdev_io = spdk_bdev_io_from_ctx(raid_io);
+    raid_bdev = raid_io->raid_bdev;
+    max_tree_size = raid_bdev->num_base_bdevs - PARITY_STRIP;
+
+    if (raid_ht == NULL) raid_ht = ht_create();
+
+    start_strip_idx = bdev_io->u.bdev.offset_blocks >> raid_bdev->strip_size_shift;
+    write_request->addr = bdev_io->u.bdev.offset_blocks * bdev_io->bdev->blocklen;
+    stripe_index = start_strip_idx / (raid_bdev->num_base_bdevs - PARITY_STRIP);
+    snprintf(stripe_key, sizeof stripe_key, "%lu", stripe_index);
+    stripe_tree = ht_get(raid_ht, stripe_key);
+
+    if (stripe_tree == NULL)
+    {
+        stripe_tree = malloc(sizeof *stripe_tree);
+        stripe_tree->size = 0;
+        RB_INIT(&stripe_tree->tree);
+        ht_set(raid_ht, stripe_key, stripe_tree);
+    }
+
+    RB_INSERT(raid_addr_tree, &stripe_tree->tree, write_request);
+    stripe_tree->size++;
+
+    if (stripe_tree->size == max_tree_size) {
+        struct raid_bdev_io *big_raid_bdev_io;
+        rc = raid_create_big_write_request(stripe_key, &big_raid_bdev_io);
+        if (rc != 0)
+        {
+            SPDK_ERRLOG("Failed to create big request\n");
+            return RAID_REQUEST_MERGE_STATUS_FAILED;
+        }
+        struct raid_write_request *current_request;
+        RB_FOREACH(current_request, raid_addr_tree, &stripe_tree->tree) {
+            raid_bdev_io_complete(current_request->bdev_io, SPDK_BDEV_IO_STATUS_SUCCESS);
+        }
+        clear_tree(stripe_tree); 
+        ht_remove(raid_ht, stripe_key);
+        free(stripe_tree);
+        return RAID_REQUEST_MERGE_STATUS_COMPLETE;
+    }
+    return RAID_REQUEST_MERGE_STATUS_WAITING_FOR_REQUESTS;
+}
+
+void 
+raid_merge_request_abort(struct raid_bdev_io *raid_io)
+{
+    struct raid_write_request *current_request;
+    struct raid_request_tree *stripe_tree;
+    struct spdk_bdev_io *bdev_io;
+    struct raid_bdev *raid_bdev;
+    char stripe_key[MAX_HT_STRING_LEN];
+    uint64_t stripe_index;
+    uint64_t start_strip_idx;
+
+    raid_bdev = raid_io->raid_bdev;
+    bdev_io = spdk_bdev_io_from_ctx(raid_io);
+    start_strip_idx = bdev_io->u.bdev.offset_blocks >> raid_bdev->strip_size_shift;
+    stripe_index = start_strip_idx / (raid_bdev->num_base_bdevs - PARITY_STRIP);
+    snprintf(stripe_key, sizeof stripe_key, "%lu", stripe_index);
+
+    stripe_tree = ht_get(raid_ht, stripe_key);
+
+    RB_FOREACH(current_request, raid_addr_tree, &stripe_tree->tree)
+    {
+        raid_bdev_io_complete(current_request->bdev_io, SPDK_BDEV_IO_STATUS_FAILED);
+    }
+    clear_tree(stripe_tree);
+    ht_remove(raid_ht, stripe_key);
+    free(stripe_tree);
+}

--- a/module/bdev/raid/raid_request_merge.h
+++ b/module/bdev/raid/raid_request_merge.h
@@ -30,6 +30,14 @@ struct raid_write_request {
     struct raid_bdev_io *bdev_io;
 };
 
+struct raid_bdev_merged_request {
+    struct raid_base_bdev_info	*base_info;
+    struct spdk_io_channel		*base_ch;
+    uint64_t pd_lba;
+	uint64_t pd_blocks;
+    struct spdk_bdev_ext_io_opts io_opts;
+};
+
 struct raid_request_tree {
     RB_HEAD(raid_addr_tree, raid_write_request) tree;
     uint64_t size;

--- a/module/bdev/raid/raid_request_merge.h
+++ b/module/bdev/raid/raid_request_merge.h
@@ -23,8 +23,7 @@ enum raid_request_merge_status {
     RAID_REQUEST_MERGE_STATUS_COMPLETE = 0,
     RAID_REQUEST_MERGE_STATUS_WAITING_FOR_REQUESTS = 1,
     RAID_REQUEST_MERGE_STATUS_FAILED = -1,
-    RAID_REQUEST_MERGE_STATUS_SKIP_FOR_ALL = -2,
-    RAID_REQUEST_MERGE_STATUS_COMPLETING = -3,
+    RAID_REQUEST_MERGE_STATUS_COMPLETING = -2,
 };
 
 struct raid_write_request {
@@ -45,17 +44,13 @@ struct raid_request_tree {
     RB_HEAD(raid_addr_tree, raid_write_request) tree;
     uint64_t size;
     uint64_t last_request_time;
-    int raid_request_merge_status;
 };
 
-struct merged_raid_bdev_io {
-    struct raid_bdev_io *big_raid_io;
-    struct raid_bdev_io *raid_io;
-};
 
 int raid_request_catch(struct raid_bdev_io *raid_io, struct raid_bdev_io **big_raid_io);
 void raid_merge_request_abort(struct raid_bdev_io *raid_io);
-int raid_request_merge_immediately(void *args);
-void get_status(int **raid_request_merge_status, struct raid_bdev_io *raid_io);
+int raid_poller_merge_helper(struct raid_bdev_io *raid_io, struct raid_bdev_io **big_raid_io);
+bool raid_get_stripe_tree_ready(struct raid_bdev_io *raid_io); 
+void  raid_free_merging_status(struct raid_bdev_io *raid_io);
 
 #endif /* SPDK_BDEV_RAID_MERGE_REQUESTS_INTERNAL_H*/

--- a/module/bdev/raid/raid_request_merge.h
+++ b/module/bdev/raid/raid_request_merge.h
@@ -1,0 +1,44 @@
+/*   SPDX-License-Identifier: BSD-3-Clause
+ *   Copyright (C) 2019 Intel Corporation.
+ *   All rights reserved.
+ *   Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ */
+
+#ifndef SPDK_BDEV_RAID_MERGE_REQUESTS_INTERNAL_H
+#define SPDK_BDEV_RAID_MERGE_REQUESTS_INTERNAL_H
+
+#include "bdev_raid.h"
+
+#include "spdk/tree.h"
+#include "spdk/log.h"
+#include "spdk/bdev.h"
+#include "spdk/bdev_module.h"
+#include "ht.h"
+
+#define MAX_HT_STRING_LEN 35
+#define PARITY_STRIP 1
+
+#define SPDK_NOTICELOG(...) \
+    spdk_log(SPDK_LOG_NOTICE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+
+enum raid_request_merge_status {
+    RAID_REQUEST_MERGE_STATUS_COMPLETE = 0,
+    RAID_REQUEST_MERGE_STATUS_WAITING_FOR_REQUESTS = 1,
+    RAID_REQUEST_MERGE_STATUS_FAILED = -1,
+};
+
+struct raid_write_request {
+    uint32_t addr;
+    RB_ENTRY(raid_write_request) link;
+    struct raid_bdev_io *bdev_io;
+};
+
+struct raid_request_tree {
+    RB_HEAD(raid_addr_tree, raid_write_request) tree;
+    uint64_t size;
+};
+
+int raid_request_catch(struct raid_bdev_io *raid_io);
+void raid_merge_request_abort(struct raid_bdev_io *raid_io);
+
+#endif /* SPDK_BDEV_RAID_MERGE_REQUESTS_INTERNAL_H*/

--- a/module/bdev/raid/raid_request_merge.h
+++ b/module/bdev/raid/raid_request_merge.h
@@ -16,10 +16,7 @@
 #include "ht.h"
 
 #define MAX_HT_STRING_LEN 35
-#define PARITY_STRIP 1
-
-#define SPDK_NOTICELOG(...) \
-    spdk_log(SPDK_LOG_NOTICE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+#define PARITY_STRIP 0
 
 enum raid_request_merge_status {
     RAID_REQUEST_MERGE_STATUS_COMPLETE = 0,
@@ -38,7 +35,7 @@ struct raid_request_tree {
     uint64_t size;
 };
 
-int raid_request_catch(struct raid_bdev_io *raid_io);
+int raid_request_catch(struct raid_bdev_io *raid_io, struct raid_bdev_io **big_raid_io);
 void raid_merge_request_abort(struct raid_bdev_io *raid_io);
 
 #endif /* SPDK_BDEV_RAID_MERGE_REQUESTS_INTERNAL_H*/


### PR DESCRIPTION
### This code implements the interface for combining requests in RAID arrays

* Requests are redirected to a function that stores them in the tree. 
* When the full-stripe accumulates, the function combines the query. 
* In case of an error, all queries saved in the tree are considered failed.

### Additional features

* A hash table was implemented to store trees by stripes. 
* Subsequently, it is planned to take it to the library for other purposes